### PR TITLE
Adds depth-first search and breadth-first search

### DIFF
--- a/tinygraph/tinygraph-tests.c
+++ b/tinygraph/tinygraph-tests.c
@@ -892,6 +892,124 @@ void test25() {
 }
 
 
+void test26() {
+  const uint32_t sources[5] = {0, 0, 1, 2, 3};
+  const uint32_t targets[5] = {1, 2, 0, 3, 2};
+
+  const tinygraph_s graph = tinygraph_construct_from_sorted_edges(
+      sources, targets, 5);
+
+  assert(graph);
+
+  tinygraph_dfs_s dfs = tinygraph_dfs_construct(graph);
+  assert(dfs);
+
+  tinygraph_dfs_set_start(dfs, 0);
+  assert(!tinygraph_dfs_is_done(dfs));
+
+  assert(tinygraph_dfs_step(dfs) == 0);
+  assert(!tinygraph_dfs_is_done(dfs));
+
+  assert(tinygraph_dfs_step(dfs) == 2);
+  assert(!tinygraph_dfs_is_done(dfs));
+
+  assert(tinygraph_dfs_step(dfs) == 3);
+  assert(!tinygraph_dfs_is_done(dfs));
+
+  assert(tinygraph_dfs_step(dfs) == 1);
+  assert(tinygraph_dfs_is_done(dfs));
+
+
+  tinygraph_dfs_clear(dfs);
+
+  tinygraph_dfs_set_start(dfs, 3);
+  assert(!tinygraph_dfs_is_done(dfs));
+
+  assert(tinygraph_dfs_step(dfs) == 3);
+  assert(!tinygraph_dfs_is_done(dfs));
+
+  assert(tinygraph_dfs_step(dfs) == 2);
+  assert(tinygraph_dfs_is_done(dfs));
+
+
+  tinygraph_dfs_clear(dfs);
+  assert(tinygraph_dfs_is_done(dfs));
+
+  tinygraph_dfs_set_start(dfs, 0);
+  assert(!tinygraph_dfs_is_done(dfs));
+
+  while (!tinygraph_dfs_is_done(dfs)) {
+    uint32_t v = tinygraph_dfs_step(dfs);
+    (void)v;
+  }
+
+  assert(tinygraph_dfs_is_done(dfs));
+
+
+  tinygraph_dfs_destruct(dfs);
+  tinygraph_destruct(graph);
+}
+
+
+void test27() {
+  const uint32_t sources[5] = {0, 0, 1, 2, 3};
+  const uint32_t targets[5] = {1, 2, 0, 3, 2};
+
+  const tinygraph_s graph = tinygraph_construct_from_sorted_edges(
+      sources, targets, 5);
+
+  assert(graph);
+
+  tinygraph_bfs_s bfs = tinygraph_bfs_construct(graph);
+  assert(bfs);
+
+  tinygraph_bfs_set_start(bfs, 0);
+  assert(!tinygraph_bfs_is_done(bfs));
+
+  assert(tinygraph_bfs_step(bfs) == 0);
+  assert(!tinygraph_bfs_is_done(bfs));
+
+  assert(tinygraph_bfs_step(bfs) == 1);
+  assert(!tinygraph_bfs_is_done(bfs));
+
+  assert(tinygraph_bfs_step(bfs) == 2);
+  assert(!tinygraph_bfs_is_done(bfs));
+
+  assert(tinygraph_bfs_step(bfs) == 3);
+  assert(tinygraph_bfs_is_done(bfs));
+
+
+  tinygraph_bfs_clear(bfs);
+
+  tinygraph_bfs_set_start(bfs, 3);
+  assert(!tinygraph_bfs_is_done(bfs));
+
+  assert(tinygraph_bfs_step(bfs) == 3);
+  assert(!tinygraph_bfs_is_done(bfs));
+
+  assert(tinygraph_bfs_step(bfs) == 2);
+  assert(tinygraph_bfs_is_done(bfs));
+
+
+  tinygraph_bfs_clear(bfs);
+  assert(tinygraph_bfs_is_done(bfs));
+
+  tinygraph_bfs_set_start(bfs, 0);
+  assert(!tinygraph_bfs_is_done(bfs));
+
+  while (!tinygraph_bfs_is_done(bfs)) {
+    uint32_t v = tinygraph_bfs_step(bfs);
+    (void)v;
+  }
+
+  assert(tinygraph_bfs_is_done(bfs));
+
+
+  tinygraph_bfs_destruct(bfs);
+  tinygraph_destruct(graph);
+}
+
+
 int main() {
   test1();
   test2();
@@ -918,4 +1036,6 @@ int main() {
   test23();
   test24();
   test25();
+  test26();
+  test27();
 }

--- a/tinygraph/tinygraph.c
+++ b/tinygraph/tinygraph.c
@@ -5,6 +5,9 @@
 #include "tinygraph.h"
 #include "tinygraph-utils.h"
 #include "tinygraph-impl.h"
+#include "tinygraph-bitset.h"
+#include "tinygraph-stack.h"
+#include "tinygraph-queue.h"
 
 
 
@@ -448,4 +451,232 @@ uint32_t tinygraph_size_in_bytes(const tinygraph * const graph) {
   return sizeof(tinygraph)
     + sizeof(uint32_t) * graph->offsets_len
     + sizeof(uint32_t) * graph->targets_len;
+}
+
+
+typedef struct tinygraph_dfs {
+  tinygraph_const_s graph;
+  tinygraph_bitset_s seen;
+  tinygraph_stack_s stack;
+} tinygraph_dfs;
+
+tinygraph_dfs_s tinygraph_dfs_construct(tinygraph_const_s graph) {
+  TINYGRAPH_ASSERT(graph);
+  TINYGRAPH_ASSERT(!tinygraph_is_empty(graph));
+
+  tinygraph_dfs *out = malloc(sizeof(tinygraph_dfs));
+
+  if (!out) {
+    return NULL;
+  }
+
+  tinygraph_bitset_s seen = tinygraph_bitset_construct(
+      tinygraph_get_num_nodes(graph));
+
+  if (!seen) {
+    free(out);
+
+    return NULL;
+  }
+
+  tinygraph_stack_s stack = tinygraph_stack_construct();
+
+  if (!stack) {
+    free(out);
+    tinygraph_bitset_destruct(seen);
+
+    return NULL;
+  }
+
+  *out = (tinygraph_dfs){
+    .graph = graph,
+    .seen = seen,
+    .stack = stack,
+  };
+
+  return out;
+}
+
+void tinygraph_dfs_destruct(tinygraph_dfs * const ctx) {
+  if (!ctx) {
+    return;
+  }
+
+  TINYGRAPH_ASSERT(ctx->seen);
+  TINYGRAPH_ASSERT(ctx->stack);
+
+  tinygraph_bitset_destruct(ctx->seen);
+  tinygraph_stack_destruct(ctx->stack);
+
+  free(ctx);
+}
+
+void tinygraph_dfs_clear(tinygraph_dfs_s ctx) {
+  TINYGRAPH_ASSERT(ctx->seen);
+  TINYGRAPH_ASSERT(ctx->stack);
+
+  tinygraph_bitset_clear(ctx->seen);
+  tinygraph_stack_clear(ctx->stack);
+}
+
+void tinygraph_dfs_set_start(tinygraph_dfs_s ctx, uint32_t v) {
+  TINYGRAPH_ASSERT(ctx->seen);
+  TINYGRAPH_ASSERT(ctx->stack);
+  TINYGRAPH_ASSERT(tinygraph_stack_is_empty(ctx->stack));
+  TINYGRAPH_ASSERT(tinygraph_has_node(ctx->graph, v));
+
+  tinygraph_bitset_set_at(ctx->seen, v);
+
+  const bool ok = tinygraph_stack_push(ctx->stack, v);
+  TINYGRAPH_ASSERT(ok);
+  (void)ok;
+}
+
+bool tinygraph_dfs_is_done(tinygraph_dfs_const_s ctx) {
+  TINYGRAPH_ASSERT(ctx->seen);
+  TINYGRAPH_ASSERT(ctx->stack);
+
+  return tinygraph_stack_is_empty(ctx->stack);
+}
+
+uint32_t tinygraph_dfs_step(tinygraph_dfs_s ctx) {
+  TINYGRAPH_ASSERT(ctx->seen);
+  TINYGRAPH_ASSERT(ctx->stack);
+  TINYGRAPH_ASSERT(ctx->graph);
+
+  TINYGRAPH_ASSERT(!tinygraph_stack_is_empty(ctx->stack));
+
+  const uint32_t s = tinygraph_stack_pop(ctx->stack);
+
+  const uint32_t *it, *last;
+
+  tinygraph_get_neighbors(ctx->graph, &it, &last, s);
+
+  for (; it != last; ++it) {
+    const uint32_t t = *it;
+
+    if (!tinygraph_bitset_get_at(ctx->seen, t)) {
+      const bool ok = tinygraph_stack_push(ctx->stack, t);
+      TINYGRAPH_ASSERT(ok);
+      (void)ok;
+
+      tinygraph_bitset_set_at(ctx->seen, t);
+    }
+  }
+
+  return s;
+}
+
+
+typedef struct tinygraph_bfs {
+  tinygraph_const_s graph;
+  tinygraph_bitset_s seen;
+  tinygraph_queue_s queue;
+} tinygraph_bfs;
+
+tinygraph_bfs_s tinygraph_bfs_construct(tinygraph_const_s graph) {
+  TINYGRAPH_ASSERT(graph);
+  TINYGRAPH_ASSERT(!tinygraph_is_empty(graph));
+
+  tinygraph_bfs *out = malloc(sizeof(tinygraph_bfs));
+
+  if (!out) {
+    return NULL;
+  }
+
+  tinygraph_bitset_s seen = tinygraph_bitset_construct(
+      tinygraph_get_num_nodes(graph));
+
+  if (!seen) {
+    free(out);
+
+    return NULL;
+  }
+
+  tinygraph_queue_s queue = tinygraph_queue_construct();
+
+  if (!queue) {
+    free(out);
+    tinygraph_bitset_destruct(seen);
+
+    return NULL;
+  }
+
+  *out = (tinygraph_bfs){
+    .graph = graph,
+    .seen = seen,
+    .queue = queue,
+  };
+
+  return out;
+}
+
+void tinygraph_bfs_destruct(tinygraph_bfs * const ctx) {
+  if (!ctx) {
+    return;
+  }
+
+  TINYGRAPH_ASSERT(ctx->seen);
+  TINYGRAPH_ASSERT(ctx->queue);
+
+  tinygraph_bitset_destruct(ctx->seen);
+  tinygraph_queue_destruct(ctx->queue);
+
+  free(ctx);
+}
+
+void tinygraph_bfs_clear(tinygraph_bfs_s ctx) {
+  TINYGRAPH_ASSERT(ctx->seen);
+  TINYGRAPH_ASSERT(ctx->queue);
+
+  tinygraph_bitset_clear(ctx->seen);
+  tinygraph_queue_clear(ctx->queue);
+}
+
+void tinygraph_bfs_set_start(tinygraph_bfs_s ctx, uint32_t v) {
+  TINYGRAPH_ASSERT(ctx->seen);
+  TINYGRAPH_ASSERT(ctx->queue);
+  TINYGRAPH_ASSERT(tinygraph_queue_is_empty(ctx->queue));
+  TINYGRAPH_ASSERT(tinygraph_has_node(ctx->graph, v));
+
+  tinygraph_bitset_set_at(ctx->seen, v);
+
+  const bool ok = tinygraph_queue_push(ctx->queue, v);
+  TINYGRAPH_ASSERT(ok);
+  (void)ok;
+}
+
+bool tinygraph_bfs_is_done(tinygraph_bfs_const_s ctx) {
+  TINYGRAPH_ASSERT(ctx->seen);
+  TINYGRAPH_ASSERT(ctx->queue);
+
+  return tinygraph_queue_is_empty(ctx->queue);
+}
+
+uint32_t tinygraph_bfs_step(tinygraph_bfs_s ctx) {
+  TINYGRAPH_ASSERT(ctx->seen);
+  TINYGRAPH_ASSERT(ctx->queue);
+  TINYGRAPH_ASSERT(ctx->graph);
+
+  TINYGRAPH_ASSERT(!tinygraph_queue_is_empty(ctx->queue));
+
+  const uint32_t s = tinygraph_queue_pop(ctx->queue);
+
+  const uint32_t *it, *last;
+
+  tinygraph_get_neighbors(ctx->graph, &it, &last, s);
+
+  for (; it != last; ++it) {
+    const uint32_t t = *it;
+
+    if (!tinygraph_bitset_get_at(ctx->seen, t)) {
+      const bool ok = tinygraph_queue_push(ctx->queue, t);
+      TINYGRAPH_ASSERT(ok);
+      (void)ok;
+
+      tinygraph_bitset_set_at(ctx->seen, t);
+    }
+  }
+
+  return s;
 }

--- a/tinygraph/tinygraph.h
+++ b/tinygraph/tinygraph.h
@@ -210,6 +210,152 @@ uint32_t tinygraph_size_in_bytes(tinygraph_const_s graph);
   for (uint32_t item = 0; item < tinygraph_get_num_edges(graph); ++item)
 
 
+/**
+ * Depth-first search context, caching internal
+ * state between multiple runs for efficiency.
+ */
+typedef struct tinygraph_dfs* tinygraph_dfs_s;
+typedef const struct tinygraph_dfs* tinygraph_dfs_const_s;
+
+/**
+ * Creates a depth-first search context for `graph`.
+ *
+ * The use case is to create a context for a graph
+ * and then run searches caching internal state.
+ *
+ * The context needs to be reset between multiple
+ * searches with `tinygraph_dfs_clear` and a start
+ * node set with `tinygraph_dfs_set_start`.
+ *
+ * Note: during the lifetime of the context, the
+ * graph it was bound to must not change.
+ *
+ * The caller is responsible to destruct the
+ * returned object with `tinygraph_dfs_destruct`.
+ */
+TINYGRAPH_API
+TINYGRAPH_WARN_UNUSED
+tinygraph_dfs_s tinygraph_dfs_construct(tinygraph_const_s graph);
+
+/**
+ * Destructs `ctx` releasing resources.
+ */
+TINYGRAPH_API
+void tinygraph_dfs_destruct(tinygraph_dfs_s ctx);
+
+/**
+ * Clears the depth-first search context so that
+ * a new graph search can be performed re-using
+ * the internal state cached by the context.
+ */
+TINYGRAPH_API
+void tinygraph_dfs_clear(tinygraph_dfs_s ctx);
+
+/**
+ * Sets the source node to `v` from which the
+ * depth-first search will start at.
+ *
+ * Setting a start node must happen exactly once
+ * either after context cunstruction, or after
+ * clearing the context for repeated searches
+ * with `tinygraph_dfs_clear`.
+ */
+TINYGRAPH_API
+void tinygraph_dfs_set_start(tinygraph_dfs_s ctx, uint32_t v);
+
+/**
+ * Returns true if the depth-first search
+ * on the graph is exhausted.
+ */
+TINYGRAPH_API
+TINYGRAPH_WARN_UNUSED
+bool tinygraph_dfs_is_done(tinygraph_dfs_const_s ctx);
+
+/**
+ * Returns the next node in the depth-first
+ * search context bound to a graph.
+ *
+ * Note: the search must not be exhausted; use
+ * in combination with `tinygraph_dfs_is_done`.
+ */
+TINYGRAPH_API
+TINYGRAPH_WARN_UNUSED
+uint32_t tinygraph_dfs_step(tinygraph_dfs_s ctx);
+
+
+/**
+ * Breadth-first search context, caching internal
+ * state between multiple runs for efficiency.
+ */
+typedef struct tinygraph_bfs* tinygraph_bfs_s;
+typedef const struct tinygraph_bfs* tinygraph_bfs_const_s;
+
+/**
+ * Creates a breadth-first search context for `graph`.
+ *
+ * The use case is to create a context for a graph
+ * and then run searches caching internal state.
+ *
+ * The context needs to be reset between multiple
+ * searches with `tinygraph_bfs_clear` and a start
+ * node set with `tinygraph_bfs_set_start`.
+ *
+ * Note: during the lifetime of the context, the
+ * graph it was bound to must not change.
+ *
+ * The caller is responsible to destruct the
+ * returned object with `tinygraph_bfs_destruct`.
+ */
+TINYGRAPH_API
+TINYGRAPH_WARN_UNUSED
+tinygraph_bfs_s tinygraph_bfs_construct(tinygraph_const_s graph);
+
+/**
+ * Destructs `ctx` releasing resources.
+ */
+TINYGRAPH_API
+void tinygraph_bfs_destruct(tinygraph_bfs_s ctx);
+
+/**
+ * Clears the breadth-first search context so that
+ * a new graph search can be performed re-using
+ * the internal state cached by the context.
+ */
+TINYGRAPH_API
+void tinygraph_bfs_clear(tinygraph_bfs_s ctx);
+
+/**
+ * Sets the source node to `v` from which the
+ * breadth-first search will start at.
+ *
+ * Setting a start node must happen exactly once
+ * either after context cunstruction, or after
+ * clearing the context for repeated searches
+ * with `tinygraph_bfs_clear`.
+ */
+TINYGRAPH_API
+void tinygraph_bfs_set_start(tinygraph_bfs_s ctx, uint32_t v);
+
+/**
+ * Returns true if the breadth-first search
+ * on the graph is exhausted.
+ */
+TINYGRAPH_API
+TINYGRAPH_WARN_UNUSED
+bool tinygraph_bfs_is_done(tinygraph_bfs_const_s ctx);
+
+/**
+ * Returns the next node in the breadth-first
+ * search context bound to a graph.
+ *
+ * Note: the search must not be exhausted; use
+ * in combination with `tinygraph_bfs_is_done`.
+ */
+TINYGRAPH_API
+TINYGRAPH_WARN_UNUSED
+uint32_t tinygraph_bfs_step(tinygraph_bfs_s ctx);
+
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
This adds an experimental library API for searchers: depth-first search and breadth-first search.

The current API proposal I ended up with is as follows

```c
// created a new search context that can be re-used across multiple searches
tinygraph_dfs_s ctx = tinygraph_dfs_construct(graph);

// for this search start at node 0
tinygraph_dfs_set_start(ctx, 0);

// step through the search space one by one
while (!tinygraph_dfs_is_done(ctx)) {
    uint32_t next = tinygraph_dfs_step(ctx);
    ..
}

// to re-use the same context, clear it and then step through another search
tinygraph_dfs_clear(ctx);
```

The main idea is that the search context can keep internal state (stack or queue and a bitset) and cache their construction and allocation between multiple searches. For example for all subsequent searches after the very first one we can simply re-use the allocated bitset and can re-use the stack or queue's internal allocations.

Open questions
- Should `clear` and `set_start` be two separate functions or should it just be one function that automatically clears the internal state whenever a new start node is set? What are the pros and cons of this design decision?
- Should we provide more customization at this point already e.g. a max depth at which to stop the search?
- Should the search stepping only return newly discovered nodes or rather return (s, t) node tuples so that the user has more information than just the new node?
- How would an easy interface look like so that we can wrap it e.g. into a Python iterator interface for ease of use?

Once we get this API into the standard `libtinygraph.h` header we better have a solid interface figured out. The alternative is adding a separate experimental header just for searches.