### PR TITLE
Adds a binary min-heap to be used as a priority queue in graph searches

### DIFF
--- a/tinygraph/Dockerfile
+++ b/tinygraph/Dockerfile
@@ -1,4 +1,4 @@
-FROM almalinux:9.4-minimal
+FROM almalinux:9.5-minimal
 
 RUN microdnf install -y --refresh --best --nodocs --noplugins --setopt=install_weak_deps=0 epel-release && \
     microdnf install -y --refresh --best --nodocs --noplugins --setopt=install_weak_deps=0 make clang libubsan libasan inotify-tools && \

--- a/tinygraph/Makefile
+++ b/tinygraph/Makefile
@@ -55,7 +55,7 @@ sanitize: all
 .PHONY: sh
 sh: clean
 	@docker build -q -t tinygraph/tinygraph .
-	@docker run -it --rm --pull never --network=none -v $(CURDIR):/app tinygraph/tinygraph
+	@docker run -it --rm --pull never --network=none -v $(CURDIR):/app:z tinygraph/tinygraph
 
 .PHONY: clean
 clean:

--- a/tinygraph/tinygraph-heap.c
+++ b/tinygraph/tinygraph-heap.c
@@ -1,14 +1,204 @@
+#include <math.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 
 #include "tinygraph-utils.h"
 #include "tinygraph-heap.h"
 
+/*
+ * Binary min-heap implemented as a dense array
+ * of heap items. Traversal happens via array
+ * indices of: parent, left child, right child.
+ *
+ * Insertion (push) happens by adding a new item
+ * at the very end (bottom right of tree) and
+ * then bubbling up the item to its position
+ * where it is smaller than its children.
+ *
+ * Removal (pop) happens by taking the very
+ * first item from the array, then switching in
+ * a new item from the very end, and bubbling
+ * it down the tree to its position where
+ * it is bigger than its parent.
+ *
+ * Both operations are in O(log n)
+ *
+ * Note that we will use this heap for graph
+ * search algorithms such as Dijkstra's. In
+ * these algorithms there's a need for a
+ * DecreaseKey operation, changing the value
+ * of an inserted item. Our simple binary
+ * min-heap here can not support this operation
+ * efficiently, but instead the work around is
+ * to e.g. insert the item with the new value
+ * again and keeping track of visited items.
+ *
+ * The benefit is that this simple binary
+ * min-heap can be implemented efficiently
+ * as a single flat array which works really
+ * well in practice on modern hardware with
+ * its cache hierarchies.
+ *
+ * In addition the combination of Dijkstra's
+ * algorithm running on rather sparse graphs
+ * such as road networks means the heap will
+ * often fit into L1, L2 caches anyway.
+ *
+ * See
+ *
+ * - https://en.wikipedia.org/wiki/Binary_heap
+ *
+ * - https://www3.cs.stonybrook.edu/~rezaul/papers/TR-07-54.pdf
+ *   Priority Queues and Dijkstra’s Algorithm
+ */
 
+// A single heap item and utility functions
+// for comparision, swapping, and traversing.
+typedef struct tinygraph_heap_item {
+  uint32_t value;
+  uint32_t priority;
+} tinygraph_heap_item;
+
+static inline bool tinygraph_heap_item_comp(
+    const tinygraph_heap_item lhs,
+    const tinygraph_heap_item rhs)
+{
+  return lhs.priority <= rhs.priority;
+}
+
+static inline void tinygraph_heap_item_swap(
+    tinygraph_heap_item * const lhs,
+    tinygraph_heap_item * const rhs)
+{
+  TINYGRAPH_ASSERT(lhs);
+  TINYGRAPH_ASSERT(rhs);
+
+  const tinygraph_heap_item tmp = *lhs;
+
+  *lhs = *rhs;
+  *rhs = tmp;
+}
+
+static inline uint32_t tinygraph_heap_item_parent(uint32_t i) {
+  TINYGRAPH_ASSERT(i > 0); // root has no parent
+
+  const uint32_t rv = (i - 1) / 2;
+
+  TINYGRAPH_ASSERT(rv < i);
+
+  return rv;
+}
+
+static inline uint32_t tinygraph_heap_item_left(uint32_t i) {
+  const uint32_t rv = 2 * i + 1;
+  TINYGRAPH_ASSERT(rv > i);
+
+  return rv;
+}
+
+static inline uint32_t tinygraph_heap_item_right(uint32_t i) {
+  const uint32_t rv = 2 * i + 2;
+  TINYGRAPH_ASSERT(rv > i);
+
+  return rv;
+}
+
+// The actual binary min-heap implemented as
+// a flat array of consecutive heap items
 typedef struct tinygraph_heap {
-  uint32_t dummy;
+  tinygraph_heap_item *items;
+  uint32_t items_len;
+  uint32_t size;
 } tinygraph_heap;
 
+
+static inline void tinygraph_heap_bubble_up(
+    tinygraph_heap * const heap, uint32_t i)
+{
+  /*
+   *      p    parent
+   *    /  \
+   *   i    o  children (we are at i)
+   *
+   *   To bubble up i, we walk upwards comparing
+   *   i with p wrt. their priority and swap them
+   *   if needed to have p <= i in a min-heap.
+   */
+  while (i > 0) {
+    const uint32_t p = tinygraph_heap_item_parent(i);
+
+    tinygraph_heap_item * const item = &heap->items[i];
+    tinygraph_heap_item * const parent = &heap->items[p];
+
+    if (tinygraph_heap_item_comp(*parent, *item)) {
+      break;
+    } else {
+      tinygraph_heap_item_swap(parent, item);
+
+      i = p;
+    }
+  }
+  // TODO: benchmark if prefetching the parent items
+  // upfront on the way up makes a difference since
+  // there is only a single path up the tree
+  // TINYGRAPH_PREFETCH();
+}
+
+static inline void tinygraph_heap_bubble_down(
+    tinygraph_heap * const heap, uint32_t i)
+{
+  /*
+   *      p    parent (we are at p=i)
+   *    /  \
+   *   l    r  children
+   *
+   * To bubble down i, we walk downwards, checking
+   * if the left or right child exist, and which
+   * way to go down.
+   */
+  while (tinygraph_heap_item_left(i) < heap->size) {
+    const uint32_t l = tinygraph_heap_item_left(i);
+    const uint32_t r = tinygraph_heap_item_right(i);
+
+    uint32_t s = i;
+
+    // go down left?
+    if (l < heap->size) {
+      tinygraph_heap_item * const left = &heap->items[l];
+      tinygraph_heap_item * const item = &heap->items[s];
+
+      if (tinygraph_heap_item_comp(*left, *item)) {
+        s = l;
+      }
+    }
+
+    // go down right?
+    if (r < heap->size) {
+      tinygraph_heap_item * const right = &heap->items[r];
+      tinygraph_heap_item * const item = &heap->items[s];
+
+      if (tinygraph_heap_item_comp(*right, *item)) {
+        s = r;
+      }
+    }
+
+    // if neither left nor right is smaller we're done here,
+    // otherwise we go down the path of the smallest child
+    if (s == i) {
+      break;
+    } else {
+      tinygraph_heap_item_swap(&heap->items[i], &heap->items[s]);
+
+      i = s;
+    }
+  }
+  // TODO: benchmark if prefetching the child items
+  // upfront on the way down makes a difference but
+  // because there is not a single path down the
+  // tree we'll have to be careful how we do it.
+  // TINYGRAPH_PREFETCH();
+}
 
 tinygraph_heap* tinygraph_heap_construct(void) {
   tinygraph_heap *out = malloc(sizeof(tinygraph_heap));
@@ -17,9 +207,202 @@ tinygraph_heap* tinygraph_heap_construct(void) {
     return NULL;
   }
 
+  // initially reserve a cacheline (64 bytes / 8 bytes struct = 8)
+  const uint32_t capacity = 8;
+
+  // TODO: we should make an initial capacity the standard
+  // in all our other datastructures, too, for consistency
+  // (e.g. in the array impl)
+
+  tinygraph_heap_item *items = calloc(capacity, sizeof(tinygraph_heap_item));
+
+  if (!items) {
+    return NULL;
+  }
+
   *out = (tinygraph_heap) {
-    .dummy = -1,
+    .items = items,
+    .items_len = capacity,
+    .size = 0,
   };
 
   return out;
+}
+
+
+tinygraph_heap* tinygraph_heap_copy(const tinygraph_heap * const heap) {
+  TINYGRAPH_ASSERT(heap);
+
+  tinygraph_heap *copy = tinygraph_heap_construct();
+
+  if (!copy) {
+    return NULL;
+  }
+
+  if (heap->size == 0) {
+    return copy;
+  }
+
+  const bool ok = tinygraph_heap_reserve(copy, heap->size);
+
+  if (!ok) {
+    tinygraph_heap_destruct(copy);
+    return NULL;
+  }
+
+  memcpy(copy->items, heap->items, heap->size * sizeof(tinygraph_heap_item));
+
+  copy->size = heap->size;
+
+  return copy;
+}
+
+
+void tinygraph_heap_destruct(tinygraph_heap * const heap) {
+  if (!heap) {
+    return;
+  }
+
+  free(heap->items);
+  free(heap);
+}
+
+
+bool tinygraph_heap_reserve(tinygraph_heap * const heap, uint32_t capacity) {
+  TINYGRAPH_ASSERT(heap);
+
+  // reserve can't resize down
+  if (capacity < heap->size) {
+    return false;
+  }
+
+  // already enough capacity
+  if (capacity <= heap->items_len) {
+    return true;
+  }
+
+  // TODO: realloc
+  tinygraph_heap_item *items = calloc(capacity, sizeof(tinygraph_heap_item));
+
+  if (!items) {
+    return false;
+  }
+
+  if (heap->size > 0) {
+    memcpy(items, heap->items, heap->size * sizeof(tinygraph_heap_item));
+  }
+
+  free(heap->items);
+
+  heap->items = items;
+  heap->items_len = capacity;
+
+  return true;
+}
+
+
+uint32_t tinygraph_heap_get_size(const tinygraph_heap * const heap) {
+  TINYGRAPH_ASSERT(heap);
+
+  return heap->size;
+}
+
+
+uint32_t tinygraph_heap_get_capacity(const tinygraph_heap * const heap) {
+  TINYGRAPH_ASSERT(heap);
+
+  return heap->items_len;
+}
+
+
+bool tinygraph_heap_is_empty(const tinygraph_heap * const heap) {
+  TINYGRAPH_ASSERT(heap);
+
+  return heap->size == 0;
+}
+
+void tinygraph_heap_clear(tinygraph_heap * const heap) {
+  TINYGRAPH_ASSERT(heap);
+
+  memset(heap->items, 0, heap->size * sizeof(tinygraph_heap_item));
+
+  heap->size = 0;
+}
+
+
+bool tinygraph_heap_push(tinygraph_heap * const heap, uint32_t value, uint32_t priority) {
+  TINYGRAPH_ASSERT(heap);
+
+  if (heap->size == UINT32_MAX) {
+    return false;
+  }
+
+  if (heap->size == heap->items_len) {
+    uint64_t growth = ceil((uint64_t)heap->items_len * 1.5);
+
+    if (growth >= UINT32_MAX) {
+      growth = UINT32_MAX;
+    }
+
+    const bool ok = tinygraph_heap_reserve(heap, (uint32_t)growth);
+
+    if (!ok) {
+      return false;
+    }
+  }
+
+  // Add a new item to the very end and then bubble it up
+  // the binary tree until it's at the correct position.
+
+  const tinygraph_heap_item item = (tinygraph_heap_item){
+    .value = value,
+    .priority = priority,
+  };
+
+  heap->items[heap->size] = item;
+  heap->size = heap->size + 1;
+
+  tinygraph_heap_bubble_up(heap, heap->size - 1);
+
+  return true;
+}
+
+
+uint32_t tinygraph_heap_pop(tinygraph_heap * const heap) {
+  TINYGRAPH_ASSERT(heap);
+  TINYGRAPH_ASSERT(heap->size > 0);
+
+  // Remove the item from the very top, swap it with the last
+  // item at the very end, and then bubble it down the binary
+  // tree until it's at the correct position.
+
+  const tinygraph_heap_item item = heap->items[0];
+
+  heap->items[0] = heap->items[heap->size - 1];
+  heap->size = heap->size - 1;
+
+  tinygraph_heap_bubble_down(heap, 0);
+
+  return item.value;
+}
+
+
+void tinygraph_heap_print_internal(const tinygraph_heap * const heap) {
+  TINYGRAPH_ASSERT(heap);
+
+  fprintf(stderr, "heap internals\n");
+
+  fprintf(stderr, "size: %ju, capacity: %ju\n",
+      (uintmax_t)heap->size, (uintmax_t)heap->items_len);
+
+  fprintf(stderr, "items:");
+
+  for (uint32_t i = 0; i < heap->size; ++i) {
+    const uint32_t value = heap->items[i].value;
+    const uint32_t priority = heap->items[i].priority;
+
+    fprintf(stderr, " (%ju, %ju)", (uintmax_t)value, (uintmax_t)priority);
+  }
+
+  fprintf(stderr, "\n");
 }

--- a/tinygraph/tinygraph-heap.h
+++ b/tinygraph/tinygraph-heap.h
@@ -7,7 +7,12 @@
 #include "tinygraph-utils.h"
 
 /*
- * Todo: implement this
+ * Simple min-heap to push items into
+ * and then pop the smallest item from
+ * efficiently. If you know about its
+ * size, make sure to reserve().
+ *
+ * Both push and pop are in O(log n)
  */
 
 typedef struct tinygraph_heap* tinygraph_heap_s;
@@ -16,5 +21,32 @@ typedef const struct tinygraph_heap* tinygraph_heap_const_s;
 
 TINYGRAPH_WARN_UNUSED
 tinygraph_heap_s tinygraph_heap_construct(void);
+
+TINYGRAPH_WARN_UNUSED
+tinygraph_heap_s tinygraph_heap_copy(tinygraph_heap_const_s heap);
+
+void tinygraph_heap_destruct(tinygraph_heap_s heap);
+
+TINYGRAPH_WARN_UNUSED
+bool tinygraph_heap_reserve(tinygraph_heap_s heap, uint32_t capacity);
+
+TINYGRAPH_WARN_UNUSED
+uint32_t tinygraph_heap_get_size(tinygraph_heap_const_s heap);
+
+TINYGRAPH_WARN_UNUSED
+uint32_t tinygraph_heap_get_capacity(tinygraph_heap_const_s heap);
+
+TINYGRAPH_WARN_UNUSED
+bool tinygraph_heap_is_empty(tinygraph_heap_const_s heap);
+
+void tinygraph_heap_clear(tinygraph_heap_s heap);
+
+TINYGRAPH_WARN_UNUSED
+bool tinygraph_heap_push(tinygraph_heap_s heap, uint32_t value, uint32_t priority);
+
+TINYGRAPH_WARN_UNUSED
+uint32_t tinygraph_heap_pop(tinygraph_heap_s heap);
+
+void tinygraph_heap_print_internal(tinygraph_heap_const_s heap);
 
 #endif

--- a/tinygraph/tinygraph-tests.c
+++ b/tinygraph/tinygraph-tests.c
@@ -15,6 +15,7 @@
 #include "tinygraph-bits.h"
 #include "tinygraph-eliasfano.h"
 #include "tinygraph-align.h"
+#include "tinygraph-heap.h"
 
 
 void test1(void) {
@@ -892,6 +893,60 @@ void test25(void) {
 }
 
 
+void test26(void) {
+  tinygraph_heap_s heap1 = tinygraph_heap_construct();
+  assert(heap1);
+  assert(tinygraph_heap_is_empty(heap1) == true);
+  assert(tinygraph_heap_get_size(heap1) == 0);
+
+  tinygraph_heap_s heap2 = tinygraph_heap_copy(heap1);
+  assert(heap2);
+  assert(tinygraph_heap_is_empty(heap2) == true);
+  assert(tinygraph_heap_get_size(heap2) == 0);
+
+  tinygraph_heap_destruct(heap1); // no longer needed
+
+  // push {value, priority} tuple, min-heap on priority
+  assert(tinygraph_heap_push(heap2, 100, 3));
+  assert(tinygraph_heap_push(heap2, 200, 1));
+  assert(tinygraph_heap_push(heap2, 300, 2));
+
+  assert(tinygraph_heap_is_empty(heap2) == false);
+  assert(tinygraph_heap_get_size(heap2) == 3);
+  assert(tinygraph_heap_get_capacity(heap2) >= 3);
+
+  assert(tinygraph_heap_pop(heap2) == 200);
+  assert(tinygraph_heap_pop(heap2) == 300);
+  assert(tinygraph_heap_pop(heap2) == 100);
+
+  tinygraph_heap_destruct(heap2);
+}
+
+
+void test27(void) {
+  tinygraph_heap_s heap = tinygraph_heap_construct();
+  assert(heap);
+
+  for (uint32_t i = 2000; i < 3000; ++i) {
+    assert(tinygraph_heap_push(heap, i, i));
+  }
+
+  for (uint32_t i = 0; i < 2000; ++i) {
+    assert(tinygraph_heap_push(heap, i, i));
+  }
+
+  for (uint32_t i = 3000; i < 4000; ++i) {
+    assert(tinygraph_heap_push(heap, i, i));
+  }
+
+  for (uint32_t i = 0; i < 4000; ++i) {
+    assert(tinygraph_heap_pop(heap) == i);
+  }
+
+  assert(tinygraph_heap_is_empty(heap));
+}
+
+
 int main(void) {
   test1();
   test2();
@@ -918,4 +973,6 @@ int main(void) {
   test23();
   test24();
   test25();
+  test26();
+  test27();
 }


### PR DESCRIPTION
For graph searches such as Dijkstra's algorithm we'll need a priority queue wrt. picking vertices to go to next.

This changeset adds a simple binary min-heap implemented as a continuous chunk of memory.

Pros
- simple to implement
- easy to reason about
- cache efficient on actual hardware
- works well in practice

Cons
- both push and pop in O(log n) but works with the realities of hardware and caches
- changing the priority of an inserted item (what folks sometimes call "decrease-key") not efficiently possible without more tricks. We'll need this e.g. in Dijkstra's algorithm. The trick is to augment this simple binary min-heap with e.g. a dense bit array of visited vertices to skip and add a new item into the min-heap instead of calling decrease-key

All in all this is a practical solution for hardware and cache hierarchies.

![800px-Binary_Heap_with_Array_Implementation](https://github.com/user-attachments/assets/38e93ae1-f0d3-4723-b796-27cf76d21f7a)
![640px-Binary_tree_in_array svg](https://github.com/user-attachments/assets/a3f54b84-0c6f-4d33-9ae4-43ca91c09648)

_from the wikipedia article below, showing the dense array layout_


- https://en.wikipedia.org/wiki/Binary_heap
- https://www3.cs.stonybrook.edu/~rezaul/papers/TR-07-54.pdf