### PR TITLE
Adds a tiny pseudo-random number generator

### DIFF
--- a/tinygraph/tinygraph-rng.c
+++ b/tinygraph/tinygraph-rng.c
@@ -1,0 +1,130 @@
+#include <stdio.h>
+#include <stdlib.h>
+
+#include "tinygraph-rng.h"
+
+/*
+ * Non-cryptographic pseudo-random number generator
+ * based on the PCG design guidelines: a linear
+ * congruential generator with output permutation.
+ *
+ * See
+ *
+ * - https://www.pcg-random.org
+ *
+ * - https://www.pcg-random.org/pdf/hmc-cs-2014-0905.pdf
+ *   Section 6.3.4 "PCG-RXS-M-XS"
+ */
+
+
+typedef struct tinygraph_rng {
+  uint32_t state;
+} tinygraph_rng;
+
+
+tinygraph_rng* tinygraph_rng_construct(void) {
+  tinygraph_rng *out = malloc(sizeof(tinygraph_rng));
+
+  if (!out) {
+    return NULL;
+  }
+
+  // Default state initializer, will always return
+  // the same sequence of pseudo-random numbers.
+
+  *out = (tinygraph_rng) {
+    .state = UINT32_C(0x46b56677),
+  };
+
+  return out;
+}
+
+
+tinygraph_rng* tinygraph_rng_construct_from_seed(uint32_t seed) {
+  tinygraph_rng *out = malloc(sizeof(tinygraph_rng));
+
+  if (!out) {
+    return NULL;
+  }
+
+  // Mixing in the seed follows the upstream pcg
+  // technique to set state to zero, step, add the
+  // seed to the state, step, and go from there.
+
+  *out = (tinygraph_rng) {
+    .state = 0,
+  };
+
+  const uint32_t v1 = tinygraph_rng_random(out);
+  (void)v1; // ignore, just step state
+
+  out->state += seed;
+
+  const uint32_t v2 = tinygraph_rng_random(out);
+  (void)v2; // ignore, just step state
+
+  return out;
+}
+
+
+tinygraph_rng* tinygraph_rng_copy(const tinygraph_rng * const rng) {
+  TINYGRAPH_ASSERT(rng);
+
+  tinygraph_rng *copy = tinygraph_rng_construct();
+
+  if (!copy) {
+    return NULL;
+  }
+
+  copy->state = rng->state;
+
+  return copy;
+}
+
+
+void tinygraph_rng_destruct(tinygraph_rng * const rng) {
+  if (!rng) {
+    return;
+  }
+
+  free(rng);
+}
+
+
+uint32_t tinygraph_rng_random(tinygraph_rng * const rng) {
+  TINYGRAPH_ASSERT(rng);
+
+  // we permute the previous state and step the rng state
+  const uint32_t state = rng->state;
+
+  // use the pcg default multiplier and increment for 32 bit
+  rng->state = rng->state * UINT32_C(747796405) + UINT32_C(2891336453);
+
+  // permute the previous state, and not the updated rng->state
+  uint32_t word = ((state >> ((state >> 28u) + 4u)) ^ state) * UINT32_C(277803737);
+
+  return (word >> 22u) ^ word;
+}
+
+
+uint32_t tinygraph_rng_bounded(tinygraph_rng * const rng, uint32_t bound) {
+  TINYGRAPH_ASSERT(rng);
+
+  uint32_t t = -bound % bound;
+
+  for (;;) {
+    uint32_t r = tinygraph_rng_random(rng);
+
+    if (r >= t)
+      return r % bound;
+  }
+}
+
+
+void tinygraph_rng_print_internal(const tinygraph_rng * const rng) {
+  TINYGRAPH_ASSERT(rng);
+
+  fprintf(stderr, "rng internals\n");
+
+  fprintf(stderr, "state: %ju\n", (uintmax_t)rng->state);
+}

--- a/tinygraph/tinygraph-rng.h
+++ b/tinygraph/tinygraph-rng.h
@@ -1,0 +1,40 @@
+#ifndef TINYGRAPH_RNG_H
+#define TINYGRAPH_RNG_H
+
+#include <stdint.h>
+
+#include "tinygraph-utils.h"
+
+/*
+ * Simple pseudo-random number generator.
+ *
+ * Note: Must not be used for cryptographic
+ * use cases. It's invertible: from its output
+ * you can re-construct its state and sequence.
+ */
+
+
+typedef struct tinygraph_rng* tinygraph_rng_s;
+typedef const struct tinygraph_rng* tinygraph_rng_const_s;
+
+
+TINYGRAPH_WARN_UNUSED
+tinygraph_rng_s tinygraph_rng_construct(void);
+
+TINYGRAPH_WARN_UNUSED
+tinygraph_rng_s tinygraph_rng_construct_from_seed(uint32_t seed);
+
+TINYGRAPH_WARN_UNUSED
+tinygraph_rng_s tinygraph_rng_copy(tinygraph_rng_const_s rng);
+
+void tinygraph_rng_destruct(tinygraph_rng_s rng);
+
+TINYGRAPH_WARN_UNUSED
+uint32_t tinygraph_rng_random(tinygraph_rng_s rng);
+
+TINYGRAPH_WARN_UNUSED
+uint32_t tinygraph_rng_bounded(tinygraph_rng_s rng, uint32_t bound);
+
+void tinygraph_rng_print_internal(tinygraph_rng_const_s rng);
+
+#endif

--- a/tinygraph/tinygraph-tests.c
+++ b/tinygraph/tinygraph-tests.c
@@ -17,6 +17,7 @@
 #include "tinygraph-align.h"
 #include "tinygraph-heap.h"
 #include "tinygraph-hash.h"
+#include "tinygraph-rng.h"
 
 
 void test1(void) {
@@ -959,6 +960,42 @@ void test28(void) {
 }
 
 
+void test29(void) {
+  tinygraph_rng_s rng = tinygraph_rng_construct();
+
+  uint32_t v1 = tinygraph_rng_random(rng);
+  uint32_t v2 = tinygraph_rng_random(rng);
+
+  assert(v1 != 0);
+  assert(v2 != 0);
+  assert(v1 != v2);
+
+  for (uint32_t i = 0; i < 100; ++i) {
+    assert(tinygraph_rng_bounded(rng, 10) <= 10);
+  }
+
+  tinygraph_rng_destruct(rng);
+}
+
+
+void test30(void) {
+  tinygraph_rng_s rng1 = tinygraph_rng_construct();
+  tinygraph_rng_s rng2 = tinygraph_rng_construct_from_seed(1);
+  tinygraph_rng_s rng3 = tinygraph_rng_construct_from_seed(2);
+
+  const uint32_t v1 = tinygraph_rng_random(rng1);
+  const uint32_t v2 = tinygraph_rng_random(rng2);
+  const uint32_t v3 = tinygraph_rng_random(rng3);
+
+  assert(v1 != v2);
+  assert(v2 != v3);
+
+  tinygraph_rng_destruct(rng1);
+  tinygraph_rng_destruct(rng2);
+  tinygraph_rng_destruct(rng3);
+}
+
+
 int main(void) {
   test1();
   test2();
@@ -988,4 +1025,6 @@ int main(void) {
   test26();
   test27();
   test28();
+  test29();
+  test30();
 }


### PR DESCRIPTION
This adds a tiny pseudo-random number generator (rng).

It is based on the pcg family of rngs and in particular `PCG-RXS-M-XS` as documented in section 6.3.4 in [the pcg paper](https://www.pcg-random.org/pdf/hmc-cs-2014-0905.pdf). It's statistically powerful but also invertible and therefore its state can be re-constructed: not a problem for our use cases.

We adapt its output permutation and use the recently discovered high quality bit mixer from the integer hashing domain.

@ucyo this is a first try at what we talked about. Now the interesting part will be evaluating it.