### PR TITLE
Uses realloc for re-allocations, closes #27

### DIFF
--- a/tinygraph/tinygraph-heap.c
+++ b/tinygraph/tinygraph-heap.c
@@ -205,10 +205,6 @@ tinygraph_heap* tinygraph_heap_construct(void) {
   // initially reserve a cacheline (64 bytes / 8 bytes struct = 8)
   const uint32_t capacity = 8;
 
-  // TODO: we should make an initial capacity the standard
-  // in all our other datastructures, too, for consistency
-  // (e.g. in the array impl)
-
   tinygraph_heap_item *items = malloc(capacity * sizeof(tinygraph_heap_item));
 
   if (!items) {
@@ -266,28 +262,18 @@ void tinygraph_heap_destruct(tinygraph_heap * const heap) {
 bool tinygraph_heap_reserve(tinygraph_heap * const heap, uint32_t capacity) {
   TINYGRAPH_ASSERT(heap);
 
-  // reserve can't resize down
-  if (capacity < heap->size) {
-    return false;
-  }
-
   // already enough capacity
   if (capacity <= heap->items_len) {
     return true;
   }
 
-  // TODO: realloc
-  tinygraph_heap_item *items = malloc(capacity * sizeof(tinygraph_heap_item));
+  TINYGRAPH_ASSERT(capacity > 0);
+
+  tinygraph_heap_item *items = realloc(heap->items, capacity * sizeof(tinygraph_heap_item));
 
   if (!items) {
     return false;
   }
-
-  if (heap->size > 0) {
-    memcpy(items, heap->items, heap->size * sizeof(tinygraph_heap_item));
-  }
-
-  free(heap->items);
 
   heap->items = items;
   heap->items_len = capacity;

--- a/tinygraph/tinygraph-tests.c
+++ b/tinygraph/tinygraph-tests.c
@@ -168,7 +168,6 @@ void test7(void) {
   assert(array1);
   assert(tinygraph_array_is_empty(array1) == true);
   assert(tinygraph_array_get_size(array1) == 0);
-  assert(tinygraph_array_get_capacity(array1) == 0);
 
   tinygraph_array_s array2 = tinygraph_array_copy(array1);
   assert(array2);
@@ -197,6 +196,24 @@ void test7(void) {
   assert(tinygraph_array_get_at(array2, 0) == 1);
   assert(tinygraph_array_get_at(array2, 7) == 0);
   tinygraph_array_destruct(array2);
+
+  tinygraph_array_s array3 = tinygraph_array_construct(8);
+  assert(array3);
+  assert(tinygraph_array_reserve(array3, 0));
+  assert(tinygraph_array_reserve(array3, 16));
+  assert(tinygraph_array_get_capacity(array3) >= 16);
+  assert(tinygraph_array_reserve(array3, 17));
+  assert(tinygraph_array_get_capacity(array3) >= 17);
+  assert(tinygraph_array_reserve(array3, 0));
+  assert(tinygraph_array_resize(array3, 0));
+  assert(tinygraph_array_get_size(array3) == 0);
+  assert(tinygraph_array_resize(array3, 16));
+  assert(tinygraph_array_get_size(array3) == 16);
+  assert(tinygraph_array_get_capacity(array3) >= 16);
+  assert(tinygraph_array_resize(array3, 17));
+  assert(tinygraph_array_get_size(array3) == 17);
+  assert(tinygraph_array_get_capacity(array3) >= 17);
+  tinygraph_array_destruct(array3);
 }
 
 


### PR DESCRIPTION
This changeset uses `realloc` for growing our dynamic memory allocations e.g. for the array and heap. Meaning it's possible now for the allocator to re-use the existing memory and extend it, in contrast to what we have done before with allocating a new chunk of memory that's bigger and manually copying over the previous data.