### PR TITLE
Re-number nodes: embed spatially based on space-filling curve, closes #17

### DIFF
--- a/tinygraph/tinygraph-impl.c
+++ b/tinygraph/tinygraph-impl.c
@@ -13,6 +13,7 @@ typedef struct tinygraph_edge {
   uint32_t target;
 } tinygraph_edge;
 
+TINYGRAPH_WARN_UNUSED
 static inline int tinygraph_edge_comp(const void* lhs, const void *rhs) {
   const tinygraph_edge elhs = *(const tinygraph_edge *)lhs;
   const tinygraph_edge erhs = *(const tinygraph_edge *)rhs;
@@ -356,7 +357,6 @@ void tinygraph_print_internal(tinygraph *graph) {
 
 
 uint8_t tinygraph_requires_num_bytes_u32(uint32_t value) {
-
   if (value < (1 << 7)) return 1;
   else if (value < (1 << 14)) return 2;
   else if (value < (1 << 21)) return 3;

--- a/tinygraph/tinygraph-sort.c
+++ b/tinygraph/tinygraph-sort.c
@@ -1,0 +1,167 @@
+#include <string.h>
+#include <stdlib.h>
+
+#include "tinygraph-sort.h"
+
+
+// This implementation is inspired by
+// https://justine.lol/sorting/
+// and adapted to make it reentrant by
+// adding a context pointer and an arg
+// parameter to the comparator much like
+// the non-standard qsort_r function.
+//
+// There are two ideas for improvements
+// 1. AVX2 bitonic sort for small ranges
+// 2. trade-off space and use radix sort
+//
+// Note that sometimes we don't need a
+// full sorting but e.g. one use case
+// is knowing the first p elements are
+// the smallest ones. In that case look
+// into nth-element like re-ordering.
+
+
+static inline void tinygraph_insertion_sort_u32(
+    uint32_t * restrict a,
+    uint32_t n,
+    int32_t (*cmp)(const uint32_t * restrict lhs, const uint32_t * restrict rhs, void * restrict arg),
+    void * restrict arg)
+{
+  for (uint32_t i = 1; i < n; ++i) {
+    uint32_t j = i - 1;
+
+    const uint32_t tmp = a[i];
+
+    while (j > 0 && cmp(&a[j], &tmp, arg) > 0) {
+      a[j + 1] = a[j];
+      j = j - 1;
+    }
+
+    a[j + 1] = tmp;
+  }
+}
+
+
+void tinygraph_sort_u32(
+    uint32_t * restrict a,
+    uint32_t n,
+    int32_t (*cmp)(const uint32_t * restrict lhs, const uint32_t * restrict rhs, void * restrict arg),
+    void * restrict arg)
+{
+  if (n < 2) {
+    return;
+  }
+
+  if (n <= 32) {
+    tinygraph_insertion_sort_u32(a, n, cmp, arg);
+  }
+
+  const uint32_t p = a[n >> 1];
+
+  uint32_t i = 0;
+
+  for (uint32_t j = n - 1; /**/; ++i, --j) {
+    while (cmp(&a[i], &p, arg) < 0) {
+      i = i + 1;
+    }
+
+    while (cmp(&a[j], &p, arg) > 0) {
+      j = j - 1;
+    }
+
+    if (i >= j) {
+      break;
+    }
+
+    const uint32_t tmp = a[i];
+    a[i] = a[j];
+    a[j] = tmp;
+  }
+
+  tinygraph_sort_u32(a, i, cmp, arg);
+  tinygraph_sort_u32(a + i, n - i, cmp, arg);
+}
+
+
+static inline void tinygraph_radix_sort_u32_with_mem(
+    uint32_t * restrict a,
+    uint32_t * restrict copy,
+    uint32_t n,
+    uint32_t (*op)(const uint32_t * restrict item, void * restrict arg),
+    void * restrict arg)
+{
+  uint32_t level0[256] = {0};
+  uint32_t level1[256] = {0};
+  uint32_t level2[256] = {0};
+  uint32_t level3[256] = {0};
+
+  for (uint32_t i = 0; i < n; ++i) {
+    const uint32_t key = op(&a[i], arg);
+
+    level0[(key >> 0UL) & 0xff]++;
+    level1[(key >> 8UL) & 0xff]++;
+    level2[(key >> 16UL) & 0xff]++;
+    level3[(key >> 24UL) & 0xff]++;
+  }
+
+  uint32_t sum0 = 0;
+  uint32_t sum1 = 0;
+  uint32_t sum2 = 0;
+  uint32_t sum3 = 0;
+
+  for (uint32_t i = 0; i < 256; ++i) {
+    uint32_t tmp0 = level0[i];
+    uint32_t tmp1 = level1[i];
+    uint32_t tmp2 = level2[i];
+    uint32_t tmp3 = level3[i];
+
+    level0[i] = sum0; sum0 += tmp0;
+    level1[i] = sum1; sum1 += tmp1;
+    level2[i] = sum2; sum2 += tmp2;
+    level3[i] = sum3; sum3 += tmp3;
+  }
+
+  for (uint32_t i = 0; i < n; ++i) {
+    const uint32_t key = op(&a[i], arg);
+    copy[level0[(key >> 0UL) & 0xff]++] = a[i];
+  }
+
+  for (uint32_t i = 0; i < n; ++i) {
+    const uint32_t key = op(&copy[i], arg);
+    a[level1[(key >> 8UL) & 0xff]++] = copy[i];
+  }
+
+  for (uint32_t i = 0; i < n; ++i) {
+    const uint32_t key = op(&a[i], arg);
+    copy[level2[(key >> 16UL) & 0xff]++] = a[i];
+  }
+
+  for (uint32_t i = 0; i < n; ++i) {
+    const uint32_t key = op(&copy[i], arg);
+    a[level3[(key >> 24UL) & 0xff]++] = copy[i];
+  }
+}
+
+bool tinygraph_radix_sort_u32(
+  uint32_t * restrict a,
+  uint32_t n,
+  uint32_t (*op)(const uint32_t * restrict item, void * restrict arg),
+  void * restrict arg)
+{
+  if (n < 2) {
+    return true;
+  }
+
+  uint32_t * const copy = malloc(n * sizeof(uint32_t));
+
+  if (!copy) {
+    return false;
+  }
+
+  tinygraph_radix_sort_u32_with_mem(a, copy, n, op, arg);
+
+  free(copy);
+
+  return true;
+}

--- a/tinygraph/tinygraph-sort.h
+++ b/tinygraph/tinygraph-sort.h
@@ -1,0 +1,42 @@
+#ifndef TINYGRAPH_SORT_H
+#define TINYGRAPH_SORT_H
+
+#include <stdint.h>
+#include <stdbool.h>
+
+#include "tinygraph-utils.h"
+
+/*
+ * Simple sorting with a comparator
+ * and a context pointer, much like
+ * the non-standard qsort_r extension.
+ *
+ * The comparator must return -1, 0, 1
+ * depending on if lhs is less, equal,
+ * or greater than rhs.
+ */
+void tinygraph_sort_u32(
+    uint32_t * restrict a,
+    uint32_t n,
+    int32_t (*cmp)(const uint32_t * restrict lhs, const uint32_t * restrict rhs, void * restrict arg),
+    void * restrict arg);
+
+/*
+ * Radix sort with a unary operation
+ * as a key extractor to sort by and
+ * a context pointer, much like the
+ * non-standard qsort_r extension.
+ *
+ * Creates a copy of the array to be
+ * sorted internally, trades off space
+ * vs runtime.
+ */
+TINYGRAPH_WARN_UNUSED
+bool tinygraph_radix_sort_u32(
+    uint32_t * restrict a,
+    uint32_t n,
+    uint32_t (*op)(const uint32_t * restrict item, void * restrict arg),
+    void * restrict arg);
+
+
+#endif

--- a/tinygraph/tinygraph.h
+++ b/tinygraph/tinygraph.h
@@ -196,6 +196,27 @@ TINYGRAPH_API
 TINYGRAPH_WARN_UNUSED
 uint32_t tinygraph_size_in_bytes(tinygraph_const_s graph);
 
+/**
+ * Reorders graph nodes based on their spatial embedding
+ * in the `n` sized `lngs` and `lats` parallel arrays:
+ *
+ * - `nodes[i]` the node i's id (can be the identity)
+ * - `lngs[i]` the longitude fixed-point for node i
+ * - `lats[i]` the latitude fixed-point for node i
+ *
+ * The caller is responsible for providing the n sized
+ * `nodes` array which will get spatially sorted inplace.
+ *
+ * It is recommended to reorder graph nodes spatially
+ * for better memory locality and reduced cache misses.
+ */
+TINYGRAPH_API
+TINYGRAPH_WARN_UNUSED
+bool tinygraph_reorder(
+    uint32_t* nodes,
+    const uint16_t* lngs,
+    const uint16_t* lats,
+    uint32_t n);
 
 /**
  * Iterates over all nodes in `graph`.


### PR DESCRIPTION
For #17 - this changeset re-orders graph nodes based on a spatial embedding: a z-order space filling curve. The exact space filling curve is an implementation detail, so that we can be flexible here in the future.

Re-ordering graph nodes spatially has two use cases
1. Memory locality when traversing a graph: with graph searches such as Dijkstra #44 if we can spatially embed the graph we can reduce cache misses considerably
2. When we encode targets as variable bytes integers (varints) we want to minimize the difference between edge targets as in: `minimize sum(targets[i + 1] - targets[i]) for i < n - 1` - as outlined in #17 this is NP-hard but the spatial embedding is a solid heuristic for graphs such as road networks

For more context read [this section in our design document](https://github.com/tinygraph/tinygraph/blob/14bb14dbb7d65ab533058dc441b12b591faae799/DESIGN.md#compress-edge-targets) on compressed edge targets and spatial order.