### PR TITLE
Adds random graphs for testing, closes #63

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 *.so*
 tinygraph-example
 tinygraph-tests
+perf.data


### PR DESCRIPTION
For #63 - this changeset adds random graph factories for testing, e.g. sparse and dense graphs, paths graphs, road network like graphs, etc. The idea is that we will use these with our graph traversal techniques to test a few ideas such as spatially embedding the graph and its impact.