### PR TITLE
Removes over-constraint assertions, closes #20

### DIFF
--- a/tinygraph/tinygraph-queue.c
+++ b/tinygraph/tinygraph-queue.c
@@ -5,6 +5,14 @@
 #include "tinygraph-stack.h"
 #include "tinygraph-queue.h"
 
+/*
+ * Simple queue implemented with two stacks
+ * lhs and rhs. We push onto the lhs, refill
+ * in reverse order onto rhs, and then take
+ * from rhs. The refill logic below makes
+ * sure we can always pop from rhs in the
+ * correct queue order by swapping in lhs.
+ */
 
 typedef struct tinygraph_queue {
   tinygraph_stack_s lhs;
@@ -13,10 +21,8 @@ typedef struct tinygraph_queue {
 
 
 TINYGRAPH_WARN_UNUSED
-static bool tinygraph_queue_refill(tinygraph_queue * const queue) {
+static inline bool tinygraph_queue_refill(tinygraph_queue * const queue) {
   TINYGRAPH_ASSERT(queue);
-  TINYGRAPH_ASSERT(queue->lhs);
-  TINYGRAPH_ASSERT(queue->rhs);
 
   if (!tinygraph_stack_reserve(queue->rhs,
         tinygraph_stack_get_size(queue->lhs))) {
@@ -124,8 +130,6 @@ void tinygraph_queue_destruct(tinygraph_queue * const queue) {
 
 bool tinygraph_queue_reserve(tinygraph_queue * const queue, uint32_t capacity) {
   TINYGRAPH_ASSERT(queue);
-  TINYGRAPH_ASSERT(queue->lhs);
-  TINYGRAPH_ASSERT(queue->rhs);
 
   if (!tinygraph_stack_reserve(queue->lhs, capacity)) {
     return false;
@@ -141,8 +145,6 @@ bool tinygraph_queue_reserve(tinygraph_queue * const queue, uint32_t capacity) {
 
 uint32_t tinygraph_queue_get_front(const tinygraph_queue * const queue) {
   TINYGRAPH_ASSERT(queue);
-  TINYGRAPH_ASSERT(queue->lhs);
-  TINYGRAPH_ASSERT(queue->rhs);
   TINYGRAPH_ASSERT(!(tinygraph_stack_is_empty(queue->lhs)
         && tinygraph_stack_is_empty(queue->rhs)));
 
@@ -156,8 +158,6 @@ uint32_t tinygraph_queue_get_front(const tinygraph_queue * const queue) {
 
 uint32_t tinygraph_queue_get_back(const tinygraph_queue * const queue) {
   TINYGRAPH_ASSERT(queue);
-  TINYGRAPH_ASSERT(queue->lhs);
-  TINYGRAPH_ASSERT(queue->rhs);
   TINYGRAPH_ASSERT(!(tinygraph_stack_is_empty(queue->lhs)
         && tinygraph_stack_is_empty(queue->rhs)));
 
@@ -171,8 +171,6 @@ uint32_t tinygraph_queue_get_back(const tinygraph_queue * const queue) {
 
 uint32_t tinygraph_queue_get_size(const tinygraph_queue * const queue) {
   TINYGRAPH_ASSERT(queue);
-  TINYGRAPH_ASSERT(queue->lhs);
-  TINYGRAPH_ASSERT(queue->rhs);
 
   const uint32_t lsize = tinygraph_stack_get_size(queue->lhs);
   const uint32_t rsize = tinygraph_stack_get_size(queue->rhs);
@@ -183,8 +181,6 @@ uint32_t tinygraph_queue_get_size(const tinygraph_queue * const queue) {
 
 uint32_t tinygraph_queue_get_capacity(const tinygraph_queue * const queue) {
   TINYGRAPH_ASSERT(queue);
-  TINYGRAPH_ASSERT(queue->lhs);
-  TINYGRAPH_ASSERT(queue->rhs);
 
   const uint32_t lcapacity = tinygraph_stack_get_capacity(queue->lhs);
   const uint32_t rcapacity = tinygraph_stack_get_capacity(queue->lhs);
@@ -195,8 +191,6 @@ uint32_t tinygraph_queue_get_capacity(const tinygraph_queue * const queue) {
 
 bool tinygraph_queue_is_empty(const tinygraph_queue * const queue) {
   TINYGRAPH_ASSERT(queue);
-  TINYGRAPH_ASSERT(queue->lhs);
-  TINYGRAPH_ASSERT(queue->rhs);
 
   if (!tinygraph_stack_is_empty(queue->lhs)) {
     return false;
@@ -212,8 +206,6 @@ bool tinygraph_queue_is_empty(const tinygraph_queue * const queue) {
 
 void tinygraph_queue_clear(tinygraph_queue * const queue) {
   TINYGRAPH_ASSERT(queue);
-  TINYGRAPH_ASSERT(queue->lhs);
-  TINYGRAPH_ASSERT(queue->rhs);
 
   tinygraph_stack_clear(queue->lhs);
   tinygraph_stack_clear(queue->rhs);
@@ -222,8 +214,6 @@ void tinygraph_queue_clear(tinygraph_queue * const queue) {
 
 bool tinygraph_queue_push(tinygraph_queue * const queue, uint32_t value) {
   TINYGRAPH_ASSERT(queue);
-  TINYGRAPH_ASSERT(queue->lhs);
-  TINYGRAPH_ASSERT(queue->rhs);
 
   return tinygraph_stack_push(queue->lhs, value);
 }
@@ -231,8 +221,6 @@ bool tinygraph_queue_push(tinygraph_queue * const queue, uint32_t value) {
 
 uint32_t tinygraph_queue_pop(tinygraph_queue * const queue) {
   TINYGRAPH_ASSERT(queue);
-  TINYGRAPH_ASSERT(queue->lhs);
-  TINYGRAPH_ASSERT(queue->rhs);
   TINYGRAPH_ASSERT(!(tinygraph_stack_is_empty(queue->lhs)
         && tinygraph_stack_is_empty(queue->rhs)));
 
@@ -241,7 +229,6 @@ uint32_t tinygraph_queue_pop(tinygraph_queue * const queue) {
     TINYGRAPH_ASSERT(ok);  // stack is corrupted
   }
 
-  TINYGRAPH_ASSERT(tinygraph_stack_is_empty(queue->lhs));
   TINYGRAPH_ASSERT(!tinygraph_stack_is_empty(queue->rhs));
 
   return tinygraph_stack_pop(queue->rhs);
@@ -250,8 +237,6 @@ uint32_t tinygraph_queue_pop(tinygraph_queue * const queue) {
 
 void tinygraph_queue_print_internal(const tinygraph_queue * const queue) {
   TINYGRAPH_ASSERT(queue);
-  TINYGRAPH_ASSERT(queue->lhs);
-  TINYGRAPH_ASSERT(queue->rhs);
 
   fprintf(stderr, "queue internals\n");
 

--- a/tinygraph/tinygraph-queue.h
+++ b/tinygraph/tinygraph-queue.h
@@ -10,11 +10,6 @@
  * Simple queue to push to the back and pop
  * from the front efficiently. If you know
  * about its size, make sure to reserve().
- *
- * Note: we implement a queue with two stacks
- * at the moment; a ringbuffer based queue
- * might make more sense for our graph walk
- * use case.
  */
 
 typedef struct tinygraph_queue* tinygraph_queue_s;

--- a/tinygraph/tinygraph-tests.c
+++ b/tinygraph/tinygraph-tests.c
@@ -350,8 +350,6 @@ void test12(void) {
   assert(queue2);
   assert(tinygraph_queue_push(queue2, 2));
   assert(tinygraph_queue_push(queue2, 3));
-  assert(tinygraph_queue_get_front(queue2) == 2);
-  assert(tinygraph_queue_get_back(queue2) == 3);
   assert(tinygraph_queue_get_size(queue2) == 2);
   tinygraph_queue_destruct(queue2);
 
@@ -359,11 +357,7 @@ void test12(void) {
   assert(queue3);
   assert(tinygraph_queue_push(queue3, 2));
   assert(tinygraph_queue_push(queue3, 3));
-  assert(tinygraph_queue_get_front(queue3) == 2);
-  assert(tinygraph_queue_get_back(queue3) == 3);
   assert(tinygraph_queue_pop(queue3) == 2);
-  assert(tinygraph_queue_get_front(queue3) == 3);
-  assert(tinygraph_queue_get_back(queue3) == 3);
   assert(tinygraph_queue_get_size(queue3) == 1);
   tinygraph_queue_destruct(queue3);
 }
@@ -1358,6 +1352,35 @@ void test35(void) {
 }
 
 
+// Note: with sanitizers enabled (e.g.
+// `make sanitize`) the test below
+// becomes noticable slower.
+//
+// This is an address sanitizer bug
+// I haven't been able to look into.
+void test36(void) {
+  tinygraph_queue_s queue = tinygraph_queue_construct();
+  assert(queue);
+
+  uint64_t sum = 0;
+
+  for (uint64_t i = 0; i < 10; ++i) {
+    for (uint32_t j = 0; j < 2; ++j) {
+      assert(tinygraph_queue_push(queue, j));
+    }
+
+    const uint32_t item = tinygraph_queue_pop(queue);
+    assert(item == (i % 2 == 0) ? 0 : 1);
+
+    sum += item;
+  }
+
+  assert(sum == 5);
+
+  tinygraph_queue_destruct(queue);
+}
+
+
 int main(void) {
   test1();
   test2();
@@ -1394,4 +1417,5 @@ int main(void) {
   test33();
   test34();
   test35();
+  test36();
 }


### PR DESCRIPTION
I've looked at https://github.com/tinygraph/tinygraph/issues/20 and benchmarked a ring buffer implementation comapring it against our two-stack approach. It's not faster, the implementation is more complicated, we would save some memory but peak memory is the same. Not worth it.

This changeset removed some over-constraint asserts we check upstream already.